### PR TITLE
misspelling in the title of Functionscancallotherfunctions.rst

### DIFF
--- a/_sources/Functions/Functionscancallotherfunctions.rst
+++ b/_sources/Functions/Functionscancallotherfunctions.rst
@@ -19,7 +19,7 @@
     composition
     function; composition
 
-Functions can call other functions (Compostion)
+Functions can call other functions (Composition)
 -----------------------------------------------
 
 It is important to understand that each of the functions we write can be used and called from other functions we 


### PR DESCRIPTION
Corrects the misspelling, adds an i to Composition